### PR TITLE
[codex] fix redis lock watchdog renewal

### DIFF
--- a/redis_lock.go
+++ b/redis_lock.go
@@ -2,6 +2,7 @@ package go_redis_lock_watchdog
 
 import (
 	"context"
+	"sync"
 	"time"
 )
 
@@ -44,7 +45,15 @@ type redisLock struct {
 	logger Logger
 
 	watchdogDuration time.Duration
-	watchdogDone     chan struct{}
+
+	delegateMu sync.Mutex
+	watchdogMu sync.Mutex
+
+	watchdog *watchdogState
+}
+
+type watchdogState struct {
+	cancel context.CancelFunc
 }
 
 // NewRedisLock creates a new RedisLock with the given name and options.
@@ -63,61 +72,106 @@ func NewRedisLock(
 }
 
 func (lock *redisLock) TryLockContext(ctx context.Context) error {
-	if err := lock.delegate.TryLockContext(ctx); err != nil {
+	lock.delegateMu.Lock()
+	err := lock.delegate.TryLockContext(ctx)
+	lock.delegateMu.Unlock()
+	if err != nil {
 		return err
 	}
-	lock.runWatchdog(ctx)
+	lock.runWatchdog()
 	return nil
 }
 
 func (lock *redisLock) LockContext(ctx context.Context) error {
-	if err := lock.delegate.LockContext(ctx); err != nil {
+	lock.delegateMu.Lock()
+	err := lock.delegate.LockContext(ctx)
+	lock.delegateMu.Unlock()
+	if err != nil {
 		return err
 	}
-	lock.runWatchdog(ctx)
+	lock.runWatchdog()
 	return nil
 }
 
 func (lock *redisLock) UnlockContext(ctx context.Context) (bool, error) {
-	lock.stopWatchdog() // stop watchdog first
+	lock.stopWatchdog()
 
+	lock.delegateMu.Lock()
+	defer lock.delegateMu.Unlock()
 	return lock.delegate.UnlockContext(ctx)
 }
 
 func (lock *redisLock) ExtendContext(ctx context.Context) (bool, error) {
-	return lock.delegate.UnlockContext(ctx)
+	lock.delegateMu.Lock()
+	defer lock.delegateMu.Unlock()
+	return lock.delegate.ExtendContext(ctx)
 }
 
-func (lock *redisLock) runWatchdog(ctx context.Context) {
+func (lock *redisLock) runWatchdog() {
 	if lock.watchdogDuration <= 0 {
 		return
 	}
 
-	lock.watchdogDone = make(chan struct{})
-	go func() {
+	lock.stopWatchdog()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	watchdog := &watchdogState{cancel: cancel}
+
+	lock.watchdogMu.Lock()
+	lock.watchdog = watchdog
+	lock.watchdogMu.Unlock()
+
+	go func(ctx context.Context, watchdog *watchdogState) {
 		ticker := time.NewTicker(lock.watchdogDuration)
-		defer ticker.Stop()
-		select {
-		case <-lock.watchdogDone:
-			return
-		case <-ctx.Done():
-			return
-		case <-ticker.C:
-			ok, err := lock.delegate.ExtendContext(ctx)
-			if err != nil {
-				lock.logger.Errorf("failed to extend lock with %s: %v", lock.name, err)
-			} else if !ok {
-				lock.logger.Errorf("failed to extend lock with %s: lock not found", lock.name)
+		defer func() {
+			ticker.Stop()
+			watchdog.cancel()
+
+			lock.watchdogMu.Lock()
+			if lock.watchdog == watchdog {
+				lock.watchdog = nil
+			}
+			lock.watchdogMu.Unlock()
+		}()
+		for {
+			select {
+			case <-ctx.Done():
 				return
-			} else {
+			case <-ticker.C:
+				extendCtx, extendCancel := context.WithTimeout(ctx, lock.watchdogDuration)
+				ok, err := lock.ExtendContext(extendCtx)
+				extendCancel()
+				if !ok {
+					if ctx.Err() != nil {
+						return
+					}
+					if err != nil {
+						lock.logger.Errorf("failed to extend lock with %s: %v", lock.name, err)
+					} else {
+						lock.logger.Errorf("failed to extend lock with %s: lock not found", lock.name)
+					}
+					return
+				}
+				if err != nil {
+					if ctx.Err() != nil {
+						return
+					}
+					lock.logger.Errorf("failed to extend lock with %s: %v", lock.name, err)
+					continue
+				}
 				lock.logger.Debugf("extend lock with %s success", lock.name)
 			}
 		}
-	}()
+	}(ctx, watchdog)
 }
 
 func (lock *redisLock) stopWatchdog() {
-	if lock.watchdogDone != nil {
-		close(lock.watchdogDone)
+	lock.watchdogMu.Lock()
+	watchdog := lock.watchdog
+	lock.watchdog = nil
+	lock.watchdogMu.Unlock()
+
+	if watchdog != nil {
+		watchdog.cancel()
 	}
 }

--- a/redis_lock.go
+++ b/redis_lock.go
@@ -2,8 +2,11 @@ package go_redis_lock_watchdog
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"time"
+
+	"github.com/go-redsync/redsync/v4"
 )
 
 type RedisLock interface {
@@ -145,6 +148,10 @@ func (lock *redisLock) runWatchdog() {
 					if ctx.Err() != nil {
 						return
 					}
+					if err != nil && !isLockOwnershipLost(err) {
+						lock.logger.Errorf("failed to extend lock with %s: %v", lock.name, err)
+						continue
+					}
 					if err != nil {
 						lock.logger.Errorf("failed to extend lock with %s: %v", lock.name, err)
 					} else {
@@ -174,4 +181,20 @@ func (lock *redisLock) stopWatchdog() {
 	if watchdog != nil {
 		watchdog.cancel()
 	}
+}
+
+func isLockOwnershipLost(err error) bool {
+	if err == nil {
+		return false
+	}
+	var errTaken *redsync.ErrTaken
+	if errors.As(err, &errTaken) {
+		return true
+	}
+	var errNodeTaken *redsync.ErrNodeTaken
+	if errors.As(err, &errNodeTaken) {
+		return true
+	}
+	return errors.Is(err, redsync.ErrExtendFailed) ||
+		errors.Is(err, redsync.ErrLockAlreadyExpired)
 }

--- a/redis_lock.go
+++ b/redis_lock.go
@@ -76,8 +76,8 @@ func NewRedisLock(
 
 func (lock *redisLock) TryLockContext(ctx context.Context) error {
 	lock.delegateMu.Lock()
+	defer lock.delegateMu.Unlock()
 	err := lock.delegate.TryLockContext(ctx)
-	lock.delegateMu.Unlock()
 	if err != nil {
 		return err
 	}
@@ -87,8 +87,8 @@ func (lock *redisLock) TryLockContext(ctx context.Context) error {
 
 func (lock *redisLock) LockContext(ctx context.Context) error {
 	lock.delegateMu.Lock()
+	defer lock.delegateMu.Unlock()
 	err := lock.delegate.LockContext(ctx)
-	lock.delegateMu.Unlock()
 	if err != nil {
 		return err
 	}
@@ -97,10 +97,9 @@ func (lock *redisLock) LockContext(ctx context.Context) error {
 }
 
 func (lock *redisLock) UnlockContext(ctx context.Context) (bool, error) {
-	lock.stopWatchdog()
-
 	lock.delegateMu.Lock()
 	defer lock.delegateMu.Unlock()
+	lock.stopWatchdog()
 	return lock.delegate.UnlockContext(ctx)
 }
 

--- a/redis_lock_test.go
+++ b/redis_lock_test.go
@@ -2,6 +2,7 @@ package go_redis_lock_watchdog_test
 
 import (
 	"context"
+	"errors"
 	"github.com/alicebob/miniredis/v2"
 	watchdog "github.com/exc-works/go-redis-lock-watchdog"
 	redsyncbuilder "github.com/exc-works/go-redis-lock-watchdog/redsync"
@@ -133,6 +134,30 @@ func TestRedisLock_WatchdogKeepsLockAcrossMultipleTicks(t *testing.T) {
 
 	contender := watchdog.NewRedisLock(builder, "test-watchdog-multiple-ticks")
 	require.Error(t, contender.TryLockContext(context.TODO()))
+}
+
+func TestRedisLock_WatchdogContinuesAfterTemporaryExtendError(t *testing.T) {
+	delegate := &fakeRedisLock{
+		extendResults: []extendResult{
+			{ok: false, err: errors.New("temporary redis error")},
+			{ok: true},
+		},
+		extendCalls: make(chan int, 2),
+	}
+	lock := watchdog.NewRedisLock(
+		func(string) watchdog.RedisLock {
+			return delegate
+		},
+		"test-watchdog-temporary-extend-error",
+		watchdog.WithWatchdogDuration(20*time.Millisecond),
+	)
+	require.NoError(t, lock.TryLockContext(context.TODO()))
+	defer func() {
+		_, _ = lock.UnlockContext(context.TODO())
+	}()
+
+	waitExtendCall(t, delegate.extendCalls)
+	waitExtendCall(t, delegate.extendCalls)
 }
 
 func TestRedisLock_WatchdogStopsAfterLockValueChanges(t *testing.T) {
@@ -300,4 +325,51 @@ func TestRedisLock_ConcurrentUnlockDoesNotPanic(t *testing.T) {
 		}()
 	}
 	wg.Wait()
+}
+
+type extendResult struct {
+	ok  bool
+	err error
+}
+
+type fakeRedisLock struct {
+	mu            sync.Mutex
+	extendResults []extendResult
+	extendCalls   chan int
+}
+
+func (f *fakeRedisLock) TryLockContext(context.Context) error {
+	return nil
+}
+
+func (f *fakeRedisLock) LockContext(context.Context) error {
+	return nil
+}
+
+func (f *fakeRedisLock) UnlockContext(context.Context) (bool, error) {
+	return true, nil
+}
+
+func (f *fakeRedisLock) ExtendContext(context.Context) (bool, error) {
+	f.mu.Lock()
+	call := len(f.extendResults)
+	result := extendResult{ok: true}
+	if call > 0 {
+		result = f.extendResults[0]
+		f.extendResults = f.extendResults[1:]
+	}
+	f.mu.Unlock()
+
+	f.extendCalls <- call
+	return result.ok, result.err
+}
+
+func waitExtendCall(t *testing.T, calls <-chan int) {
+	t.Helper()
+
+	select {
+	case <-calls:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("timed out waiting for watchdog extend call")
+	}
 }

--- a/redis_lock_test.go
+++ b/redis_lock_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"log/slog"
 	"os"
+	"sync"
 	"testing"
 	"time"
 )
@@ -70,4 +71,233 @@ func TestRedisLock_TryLockContext(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, ok)
 	})
+}
+
+func TestRedisLock_ExtendContext(t *testing.T) {
+	mr := miniredis.RunT(t)
+	defer mr.Close()
+
+	cli := redis.NewClient(&redis.Options{
+		Addr: mr.Addr(),
+	})
+	defer cli.Close()
+
+	builder := redsyncbuilder.NewRedisLockBuilder(
+		redsync.New(goredis.NewPool(cli)),
+		redsync.WithTries(1),
+		redsync.WithExpiry(500*time.Millisecond),
+	)
+	lock := watchdog.NewRedisLock(builder, "test-extend")
+	require.NoError(t, lock.TryLockContext(context.TODO()))
+	defer func() {
+		_, _ = lock.UnlockContext(context.TODO())
+	}()
+
+	time.Sleep(350 * time.Millisecond)
+
+	ok, err := lock.ExtendContext(context.TODO())
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	time.Sleep(250 * time.Millisecond)
+
+	contender := watchdog.NewRedisLock(builder, "test-extend")
+	require.Error(t, contender.TryLockContext(context.TODO()))
+}
+
+func TestRedisLock_WatchdogKeepsLockAcrossMultipleTicks(t *testing.T) {
+	mr := miniredis.RunT(t)
+	defer mr.Close()
+
+	cli := redis.NewClient(&redis.Options{
+		Addr: mr.Addr(),
+	})
+	defer cli.Close()
+
+	builder := redsyncbuilder.NewRedisLockBuilder(
+		redsync.New(goredis.NewPool(cli)),
+		redsync.WithTries(1),
+		redsync.WithExpiry(200*time.Millisecond),
+	)
+	lock := watchdog.NewRedisLock(
+		builder,
+		"test-watchdog-multiple-ticks",
+		watchdog.WithWatchdogDuration(50*time.Millisecond),
+	)
+	require.NoError(t, lock.TryLockContext(context.TODO()))
+	defer func() {
+		_, _ = lock.UnlockContext(context.TODO())
+	}()
+
+	time.Sleep(550 * time.Millisecond)
+
+	contender := watchdog.NewRedisLock(builder, "test-watchdog-multiple-ticks")
+	require.Error(t, contender.TryLockContext(context.TODO()))
+}
+
+func TestRedisLock_WatchdogStopsAfterLockValueChanges(t *testing.T) {
+	mr := miniredis.RunT(t)
+	defer mr.Close()
+
+	cli := redis.NewClient(&redis.Options{
+		Addr: mr.Addr(),
+	})
+	defer cli.Close()
+
+	const lockName = "test-watchdog-stops-after-value-change"
+	builder := redsyncbuilder.NewRedisLockBuilder(
+		redsync.New(goredis.NewPool(cli)),
+		redsync.WithTries(1),
+		redsync.WithExpiry(200*time.Millisecond),
+		redsync.WithSetNXOnExtend(),
+	)
+	lock := watchdog.NewRedisLock(
+		builder,
+		lockName,
+		watchdog.WithWatchdogDuration(50*time.Millisecond),
+	)
+	require.NoError(t, lock.TryLockContext(context.TODO()))
+	defer func() {
+		_, _ = lock.UnlockContext(context.TODO())
+	}()
+
+	require.NoError(t, cli.Set(context.TODO(), lockName, "another-owner", time.Second).Err())
+	time.Sleep(120 * time.Millisecond)
+	require.NoError(t, cli.Del(context.TODO(), lockName).Err())
+	time.Sleep(120 * time.Millisecond)
+
+	contender := watchdog.NewRedisLock(builder, lockName)
+	require.NoError(t, contender.TryLockContext(context.TODO()))
+	_, _ = contender.UnlockContext(context.TODO())
+}
+
+func TestRedisLock_WatchdogOutlivesLockContext(t *testing.T) {
+	mr := miniredis.RunT(t)
+	defer mr.Close()
+
+	cli := redis.NewClient(&redis.Options{
+		Addr: mr.Addr(),
+	})
+	defer cli.Close()
+
+	builder := redsyncbuilder.NewRedisLockBuilder(
+		redsync.New(goredis.NewPool(cli)),
+		redsync.WithTries(1),
+		redsync.WithExpiry(200*time.Millisecond),
+	)
+	lockCtx, cancel := context.WithCancel(context.Background())
+	lock := watchdog.NewRedisLock(
+		builder,
+		"test-watchdog-outlives-lock-context",
+		watchdog.WithWatchdogDuration(50*time.Millisecond),
+	)
+	require.NoError(t, lock.TryLockContext(lockCtx))
+	defer func() {
+		_, _ = lock.UnlockContext(context.TODO())
+	}()
+
+	cancel()
+	time.Sleep(550 * time.Millisecond)
+
+	contender := watchdog.NewRedisLock(builder, "test-watchdog-outlives-lock-context")
+	require.Error(t, contender.TryLockContext(context.TODO()))
+}
+
+func TestRedisLock_UnlockStopsWatchdogAndAllowsRelock(t *testing.T) {
+	mr := miniredis.RunT(t)
+	defer mr.Close()
+
+	cli := redis.NewClient(&redis.Options{
+		Addr: mr.Addr(),
+	})
+	defer cli.Close()
+
+	builder := redsyncbuilder.NewRedisLockBuilder(
+		redsync.New(goredis.NewPool(cli)),
+		redsync.WithTries(1),
+		redsync.WithExpiry(200*time.Millisecond),
+	)
+	lock := watchdog.NewRedisLock(
+		builder,
+		"test-watchdog-unlock",
+		watchdog.WithWatchdogDuration(50*time.Millisecond),
+	)
+	require.NoError(t, lock.TryLockContext(context.TODO()))
+
+	ok, err := lock.UnlockContext(context.TODO())
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	time.Sleep(150 * time.Millisecond)
+
+	contender := watchdog.NewRedisLock(builder, "test-watchdog-unlock")
+	require.NoError(t, contender.TryLockContext(context.TODO()))
+	_, _ = contender.UnlockContext(context.TODO())
+}
+
+func TestRedisLock_CanReuseSameInstanceAfterUnlock(t *testing.T) {
+	mr := miniredis.RunT(t)
+	defer mr.Close()
+
+	cli := redis.NewClient(&redis.Options{
+		Addr: mr.Addr(),
+	})
+	defer cli.Close()
+
+	builder := redsyncbuilder.NewRedisLockBuilder(
+		redsync.New(goredis.NewPool(cli)),
+		redsync.WithTries(1),
+		redsync.WithExpiry(200*time.Millisecond),
+	)
+	lock := watchdog.NewRedisLock(
+		builder,
+		"test-watchdog-reuse",
+		watchdog.WithWatchdogDuration(50*time.Millisecond),
+	)
+	require.NoError(t, lock.TryLockContext(context.TODO()))
+	ok, err := lock.UnlockContext(context.TODO())
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	require.NoError(t, lock.TryLockContext(context.TODO()))
+	defer func() {
+		_, _ = lock.UnlockContext(context.TODO())
+	}()
+
+	time.Sleep(550 * time.Millisecond)
+
+	contender := watchdog.NewRedisLock(builder, "test-watchdog-reuse")
+	require.Error(t, contender.TryLockContext(context.TODO()))
+}
+
+func TestRedisLock_ConcurrentUnlockDoesNotPanic(t *testing.T) {
+	mr := miniredis.RunT(t)
+	defer mr.Close()
+
+	cli := redis.NewClient(&redis.Options{
+		Addr: mr.Addr(),
+	})
+	defer cli.Close()
+
+	builder := redsyncbuilder.NewRedisLockBuilder(
+		redsync.New(goredis.NewPool(cli)),
+		redsync.WithTries(1),
+		redsync.WithExpiry(200*time.Millisecond),
+	)
+	lock := watchdog.NewRedisLock(
+		builder,
+		"test-watchdog-concurrent-unlock",
+		watchdog.WithWatchdogDuration(50*time.Millisecond),
+	)
+	require.NoError(t, lock.TryLockContext(context.TODO()))
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = lock.UnlockContext(context.TODO())
+		}()
+	}
+	wg.Wait()
 }


### PR DESCRIPTION
## Summary

- Fix `ExtendContext` so the watchdog extends the Redis lock instead of unlocking it.
- Make the watchdog renew repeatedly until unlock or lock loss, with an independent lifecycle from the lock-acquisition context.
- Serialize lock delegate access and watchdog state changes to avoid concurrent unlock / reuse races.
- Add regression coverage for multi-tick renewal, cancelled acquisition contexts, lock loss, unlock stop behavior, same-instance reuse, and concurrent unlock.

## Root Cause

The watchdog only attempted one renewal and then exited, so long-running jobs could lose the Redis lock after the original TTL. The wrapper `ExtendContext` also delegated to `UnlockContext`, which could accidentally release a lock when callers tried to extend it.

## Validation

- `go test ./...`
- `go test -race ./...`
- `go build ./...`
- `go test -count=3 ./...`

Note: an existing unstaged `go.sum` change was left out of this PR.