### PR TITLE
[codex] Expand Redis extend error logs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.22
 require (
 	github.com/alicebob/miniredis/v2 v2.34.0
 	github.com/go-redsync/redsync/v4 v4.13.0
+	github.com/hashicorp/go-multierror v1.1.1
 	github.com/redis/go-redis/v9 v9.5.1
 	github.com/stretchr/testify v1.10.0
 )
@@ -17,7 +18,6 @@ require (
 	github.com/go-co-op/gocron/v2 v2.14.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
-	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/jonboulle/clockwork v0.4.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/robfig/cron/v3 v3.0.1 // indirect

--- a/redis_lock.go
+++ b/redis_lock.go
@@ -3,10 +3,13 @@ package go_redis_lock_watchdog
 import (
 	"context"
 	"errors"
+	"fmt"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/go-redsync/redsync/v4"
+	"github.com/hashicorp/go-multierror"
 )
 
 type RedisLock interface {
@@ -148,21 +151,17 @@ func (lock *redisLock) runWatchdog() {
 						return
 					}
 					if err != nil && !isLockOwnershipLost(err) {
-						lock.logger.Errorf("failed to extend lock with %s: %v", lock.name, err)
+						lock.logger.Errorf("failed to extend lock with %s: %s", lock.name, formatExtendError(err))
 						continue
 					}
-					if err != nil {
-						lock.logger.Errorf("failed to extend lock with %s: %v", lock.name, err)
-					} else {
-						lock.logger.Errorf("failed to extend lock with %s: lock not found", lock.name)
-					}
+					lock.logger.Errorf("failed to extend lock with %s: %s", lock.name, formatExtendError(err))
 					return
 				}
 				if err != nil {
 					if ctx.Err() != nil {
 						return
 					}
-					lock.logger.Errorf("failed to extend lock with %s: %v", lock.name, err)
+					lock.logger.Errorf("failed to extend lock with %s: %s", lock.name, formatExtendError(err))
 					continue
 				}
 				lock.logger.Debugf("extend lock with %s success", lock.name)
@@ -196,4 +195,66 @@ func isLockOwnershipLost(err error) bool {
 	}
 	return errors.Is(err, redsync.ErrExtendFailed) ||
 		errors.Is(err, redsync.ErrLockAlreadyExpired)
+}
+
+func formatExtendError(err error) string {
+	if err == nil {
+		return "lock not found"
+	}
+
+	var multiErr *multierror.Error
+	if errors.As(err, &multiErr) {
+		if len(multiErr.Errors) == 0 {
+			return formatSingleExtendError(err)
+		}
+
+		parts := make([]string, 0, len(multiErr.Errors))
+		for i, child := range multiErr.Errors {
+			parts = append(parts, fmt.Sprintf("error[%d]=%s", i, formatSingleExtendError(child)))
+		}
+		return strings.Join(parts, "; ")
+	}
+
+	return formatSingleExtendError(err)
+}
+
+func formatSingleExtendError(err error) string {
+	if err == nil {
+		return "<nil>"
+	}
+
+	var redisErr *redsync.RedisError
+	if errors.As(err, &redisErr) {
+		return fmt.Sprintf("%T: node=%d err=%s", redisErr, redisErr.Node, formatSingleExtendError(redisErr.Err))
+	}
+
+	var nodeTaken *redsync.ErrNodeTaken
+	if errors.As(err, &nodeTaken) {
+		return fmt.Sprintf("%T: node=%d message=%s", nodeTaken, nodeTaken.Node, nonEmptyErrorMessage(err))
+	}
+
+	var taken *redsync.ErrTaken
+	if errors.As(err, &taken) {
+		return fmt.Sprintf("%T: nodes=%v message=%s", taken, taken.Nodes, nonEmptyErrorMessage(err))
+	}
+
+	switch {
+	case errors.Is(err, redsync.ErrLockAlreadyExpired):
+		return fmt.Sprintf("redsync.ErrLockAlreadyExpired: %s", redsync.ErrLockAlreadyExpired)
+	case errors.Is(err, redsync.ErrExtendFailed):
+		return fmt.Sprintf("redsync.ErrExtendFailed: %s", redsync.ErrExtendFailed)
+	default:
+		return fmt.Sprintf("%T: %s", err, nonEmptyErrorMessage(err))
+	}
+}
+
+func nonEmptyErrorMessage(err error) string {
+	if err == nil {
+		return "<nil>"
+	}
+	message := err.Error()
+	if message == "" {
+		return "<empty error message>"
+	}
+	return message
 }

--- a/redis_lock_test.go
+++ b/redis_lock_test.go
@@ -3,15 +3,18 @@ package go_redis_lock_watchdog_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"github.com/alicebob/miniredis/v2"
 	watchdog "github.com/exc-works/go-redis-lock-watchdog"
 	redsyncbuilder "github.com/exc-works/go-redis-lock-watchdog/redsync"
 	"github.com/go-redsync/redsync/v4"
 	"github.com/go-redsync/redsync/v4/redis/goredis/v9"
+	"github.com/hashicorp/go-multierror"
 	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/require"
 	"log/slog"
 	"os"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -158,6 +161,106 @@ func TestRedisLock_WatchdogContinuesAfterTemporaryExtendError(t *testing.T) {
 
 	waitExtendCall(t, delegate.extendCalls)
 	waitExtendCall(t, delegate.extendCalls)
+}
+
+func TestRedisLock_WatchdogLogsExpandedMultiErrorAndStopsOnOwnershipLoss(t *testing.T) {
+	logger := &captureLogger{}
+	delegate := &fakeRedisLock{
+		extendResults: []extendResult{
+			{ok: false, err: multierror.Append(nil, &redsync.ErrNodeTaken{Node: 7})},
+		},
+		extendCalls: make(chan int, 2),
+	}
+	lock := watchdog.NewRedisLock(
+		func(string) watchdog.RedisLock {
+			return delegate
+		},
+		"test-watchdog-expanded-multierror",
+		watchdog.WithWatchdogDuration(20*time.Millisecond),
+		watchdog.WithLogger(logger),
+	)
+	require.NoError(t, lock.TryLockContext(context.TODO()))
+	defer func() {
+		_, _ = lock.UnlockContext(context.TODO())
+	}()
+
+	waitExtendCall(t, delegate.extendCalls)
+	require.Eventually(t, func() bool {
+		message := logger.joinedErrors()
+		return strings.Contains(message, "error[0]=") &&
+			strings.Contains(message, "redsync.ErrNodeTaken") &&
+			strings.Contains(message, "node=7")
+	}, 200*time.Millisecond, 10*time.Millisecond)
+
+	select {
+	case <-delegate.extendCalls:
+		t.Fatal("watchdog continued after ownership loss")
+	case <-time.After(80 * time.Millisecond):
+	}
+}
+
+func TestRedisLock_WatchdogLogsEmptyChildErrorMessage(t *testing.T) {
+	logger := &captureLogger{}
+	delegate := &fakeRedisLock{
+		extendResults: []extendResult{
+			{ok: false, err: multierror.Append(nil, emptyExtendError{})},
+			{ok: true},
+		},
+		extendCalls: make(chan int, 2),
+	}
+	lock := watchdog.NewRedisLock(
+		func(string) watchdog.RedisLock {
+			return delegate
+		},
+		"test-watchdog-empty-child-error",
+		watchdog.WithWatchdogDuration(20*time.Millisecond),
+		watchdog.WithLogger(logger),
+	)
+	require.NoError(t, lock.TryLockContext(context.TODO()))
+	defer func() {
+		_, _ = lock.UnlockContext(context.TODO())
+	}()
+
+	waitExtendCall(t, delegate.extendCalls)
+	waitExtendCall(t, delegate.extendCalls)
+	require.Eventually(t, func() bool {
+		message := logger.joinedErrors()
+		return strings.Contains(message, "error[0]=") &&
+			strings.Contains(message, "emptyExtendError") &&
+			strings.Contains(message, "<empty error message>")
+	}, 200*time.Millisecond, 10*time.Millisecond)
+}
+
+func TestRedisLock_WatchdogLogsRedisErrorNodeAndInnerMessage(t *testing.T) {
+	logger := &captureLogger{}
+	delegate := &fakeRedisLock{
+		extendResults: []extendResult{
+			{ok: false, err: multierror.Append(nil, &redsync.RedisError{Node: 3, Err: emptyExtendError{}})},
+			{ok: true},
+		},
+		extendCalls: make(chan int, 2),
+	}
+	lock := watchdog.NewRedisLock(
+		func(string) watchdog.RedisLock {
+			return delegate
+		},
+		"test-watchdog-redis-error",
+		watchdog.WithWatchdogDuration(20*time.Millisecond),
+		watchdog.WithLogger(logger),
+	)
+	require.NoError(t, lock.TryLockContext(context.TODO()))
+	defer func() {
+		_, _ = lock.UnlockContext(context.TODO())
+	}()
+
+	waitExtendCall(t, delegate.extendCalls)
+	waitExtendCall(t, delegate.extendCalls)
+	require.Eventually(t, func() bool {
+		message := logger.joinedErrors()
+		return strings.Contains(message, "redsync.RedisError") &&
+			strings.Contains(message, "node=3") &&
+			strings.Contains(message, "<empty error message>")
+	}, 200*time.Millisecond, 10*time.Millisecond)
 }
 
 func TestRedisLock_WatchdogStopsAfterLockValueChanges(t *testing.T) {
@@ -372,4 +475,33 @@ func waitExtendCall(t *testing.T, calls <-chan int) {
 	case <-time.After(200 * time.Millisecond):
 		t.Fatal("timed out waiting for watchdog extend call")
 	}
+}
+
+type emptyExtendError struct{}
+
+func (emptyExtendError) Error() string {
+	return ""
+}
+
+type captureLogger struct {
+	mu     sync.Mutex
+	errors []string
+}
+
+func (c *captureLogger) Debugf(string, ...any) {}
+
+func (c *captureLogger) Infof(string, ...any) {}
+
+func (c *captureLogger) Warnf(string, ...any) {}
+
+func (c *captureLogger) Errorf(format string, args ...any) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.errors = append(c.errors, fmt.Sprintf(format, args...))
+}
+
+func (c *captureLogger) joinedErrors() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return strings.Join(c.errors, "\n")
 }


### PR DESCRIPTION
## Summary
- expand watchdog extend failure logs so redsync multierror children are visible
- include node/type details for Redis and ownership-loss errors
- make empty child error strings explicit with a placeholder

## Root Cause
The watchdog logged only the top-level `err.Error()`. Redsync can return `hashicorp/go-multierror`, so logs could show only `1 error occurred:` when the child error string was empty or not visible in single-line log output.

## Validation
- `go test ./...`
- `git diff --check -- redis_lock.go redis_lock_test.go go.mod`

## Notes
The PR keeps lock behavior unchanged: retryable extend errors continue the watchdog, while ownership-lost errors still stop it after logging expanded details.